### PR TITLE
Add 200k max points option

### DIFF
--- a/index.html
+++ b/index.html
@@ -1564,7 +1564,7 @@
                   data-stored="points"
                   type="range"
                   min="1"
-                  max="13"
+                  max="14"
                   value="4"
                   data-cells="10000"
                 />
@@ -5804,7 +5804,7 @@
           <div data-tip="Set points (cells) number of the submap" style="display: flex; gap: 1em">
             <div>Points number</div>
             <div>
-              <input id="submapPointsInput" type="range" min="1" max="13" value="4" />
+              <input id="submapPointsInput" type="range" min="1" max="14" value="4" />
               <output id="submapPointsFormatted" style="color: #053305">10K</output>
             </div>
           </div>
@@ -5835,7 +5835,7 @@
         >
           <div>Points number</div>
           <div>
-            <input id="transformPointsInput" type="range" min="1" max="13" value="4" />
+            <input id="transformPointsInput" type="range" min="1" max="14" value="4" />
             <output id="transformPointsFormatted" style="color: #053305">10K</output>
           </div>
 

--- a/modules/heightmap-generator.js
+++ b/modules/heightmap-generator.js
@@ -101,7 +101,8 @@ window.HeightmapGenerator = (function () {
       70000: 0.9955,
       80000: 0.996,
       90000: 0.9964,
-      100000: 0.9973
+      100000: 0.9973,
+      200000: 0.998
     };
     return blobPowerMap[cells] || 0.98;
   }
@@ -120,7 +121,8 @@ window.HeightmapGenerator = (function () {
       70000: 0.88,
       80000: 0.91,
       90000: 0.92,
-      100000: 0.93
+      100000: 0.93,
+      200000: 0.94
     };
 
     return linePowerMap[cells] || 0.81;

--- a/modules/ui/options.js
+++ b/modules/ui/options.js
@@ -327,7 +327,8 @@ const cellsDensityMap = {
   10: 70000,
   11: 80000,
   12: 90000,
-  13: 100000
+  13: 100000,
+  14: 200000
 };
 
 function changeCellsDensity(value) {


### PR DESCRIPTION
## Summary
- raise `pointsInput` slider upper bound
- allow Submap and Transform tools to go up to 200k cells
- extend `cellsDensityMap` in options
- provide parameters for 200k in the heightmap generator

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68705839284483298dd1b188d7eb0339